### PR TITLE
estat: 秘匿処理 (合算) されたメッシュパッチ数を結果に含める

### DIFF
--- a/japanese_grids/algorithms/load_estat_csv.py
+++ b/japanese_grids/algorithms/load_estat_csv.py
@@ -187,6 +187,7 @@ class LoadEstatGridSquareStats(QgsProcessingAlgorithm):
 
         # TODO: refactor
 
+        num_gassan_idx = None
         with open(filename, encoding="cp932") as f:
             columns, aliases = _load_header(f)
             # Make fields
@@ -200,6 +201,10 @@ class LoadEstatGridSquareStats(QgsProcessingAlgorithm):
                 else:
                     field = QgsField(name, type=QVariant.Int)
                 fields.append(field)
+
+            if "GASSAN" in columns:
+                fields.append(QgsField("NUM_GASSAN", type=QVariant.Int))
+                num_gassan_idx = len(fields) - 1
 
             (sink, dest_id) = self.parameterAsSink(
                 parameters,
@@ -300,6 +305,9 @@ class LoadEstatGridSquareStats(QgsProcessingAlgorithm):
             elif len(geoms) > 1:
                 # 合算されている場合はジオメトリを合成
                 feat.setGeometry(QgsGeometry.unaryUnion(QgsGeometry(p) for p in geoms))
+
+            if merge_hitoku and num_gassan_idx is not None:
+                feat.setAttribute(num_gassan_idx, len(geoms))
 
             sink.addFeature(feat, QgsFeatureSink.FastInsert)
 

--- a/japanese_grids/metadata.txt
+++ b/japanese_grids/metadata.txt
@@ -1,6 +1,6 @@
 [general]
 name=Japanese Grid Mesh
-version=1.5.0
+version=1.6.0
 qgisMinimumVersion=3.6
 description=Create common grid squares used in Japan. 日本で使われている「標準地域メッシュ」および「国土基本図図郭」のポリゴンを作成できるほか、国勢調査や経済センサスなどの「地域メッシュ統計」のCSVファイルを読み込むこともできます。プロセッシングツールボックスから利用できます。また、地図キャンバス上のマウスカーソル位置の地域メッシュコードをリアルタイムに表示するパネルも搭載しています。
 author=MIERUNE Inc.


### PR DESCRIPTION
秘匿処理されたメッシュパッチに正しいシンボロジを与えるには、統計量をパッチ数で按分する必要がある。これを行うため、合算されたメッシュパッチ数を `NUM_GASSAN` というフィールドとして提供する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - CSVデータ処理において、特定のカラムが存在する場合、関連するジオメトリ数が反映される機能を追加しました。

- **Chores**
  - プラグインのバージョンが1.5.0から1.6.0に更新されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->